### PR TITLE
ci: make Windows best-effort (non-blocking) in CI

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -54,7 +54,13 @@ jobs:
         working-directory: ./frontend
   test:
     runs-on: ${{ matrix.os }}
+    # We prioritise Linux and macOS. Windows is best-effort / optional:
+    # keep it in CI but allow it to fail without blocking the workflow.
+    continue-on-error: ${{ startsWith(matrix.os, 'windows') }}
     strategy:
+      # Don't cancel the other OS legs when one fails, so Windows and
+      # the required Linux/macOS legs report independently.
+      fail-fast: false
       matrix:
         os: [ ubuntu-22.04, windows-latest, macOS-latest ]
         rust: [ stable ]

--- a/bindings/python/.githubx/workflows/CI.yml
+++ b/bindings/python/.githubx/workflows/CI.yml
@@ -44,6 +44,9 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    # Windows wheels are best-effort / optional: a failure here must not block
+    # the Linux/macOS wheels or the release job (which `needs` this job).
+    continue-on-error: true
     strategy:
       matrix:
         target: [x64, x86]


### PR DESCRIPTION
## What & why

We're prioritising **Linux and macOS** and don't have the capacity to keep Windows green right now. This keeps Windows in CI as a **best-effort / optional** target — it still runs, but a failure no longer blocks the workflow.

There is **no Windows-specific source code** in the repo (no `#[cfg(windows)]`, no `winapi`/`msvc` deps — the `windows` hits in `.rs` files are SQL window functions / `slice::windows()`), so this is a **CI-only** change. Windows is intentionally kept in the matrix, not removed.

## Changes

- **`.github/workflows/build-latest.yml`** (Develop Check — gates PRs): the `test` job now sets
  - `continue-on-error: ${{ startsWith(matrix.os, 'windows') }}` → the Windows leg is non-blocking; Linux + macOS stay required.
  - `fail-fast: false` → a failure in one OS leg no longer cancels the others, so Linux/macOS report independently of Windows.
- **`bindings/python/.githubx/workflows/CI.yml`**: the `windows` wheel job is now `continue-on-error: true`, so a failing Windows wheel can't block the Linux/macOS wheels or the `release` job that `needs` it. _(Note: this workflow lives in `.githubx/` and is currently disabled; updated for consistency in case it's re-enabled.)_

## Already optional (unchanged)

- `.github/workflows/release.yml` — the `publish` job already has job-level `continue-on-error: true`, so the Windows release build is already best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
